### PR TITLE
docs(README): add missing protocol to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Setup
 
-In order to use the action, you have to [register a GitHub app](github.com/settings/apps/new).
+In order to use the action, you have to [register a GitHub app](https://github.com/settings/apps/new).
 
 - `GitHub App name`: set to something like `<Your Project> Release Notifier`
 - `Description`: copy/paste most of this repository's [Notifier app](https://github.com/settings/installations/12807923). Make sure to replace `release-notifier-release` with `<your-project>-release`


### PR DESCRIPTION
for creating a new GitHub App

Fix #61 