### PR TITLE
fix: use `node16` instead of `node12`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: "The name of the repository dispatch event, see https://git.io/JTpRo. Defaults to '[owner]/[repo] release', e.g. 'gr2m/release-notifier-action release'"
     required: false
 runs:
-  using: "node12"
+  using: "node18"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -14,5 +14,5 @@ inputs:
     description: "The name of the repository dispatch event, see https://git.io/JTpRo. Defaults to '[owner]/[repo] release', e.g. 'gr2m/release-notifier-action release'"
     required: false
 runs:
-  using: "node18"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
This should resolve #147 and the deprecation warnings for NodeJS v12 actions